### PR TITLE
Ensure action built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,16 @@ jobs:
       - run: yarn install
       - run: yarn run build
       - run: yarn run eslint
+      - run:
+          name: Check action built
+          command: |
+            if output=$(git status --porcelain) && [ -z "$output" ]; then
+              echo "Git status clean"
+            else
+              git status
+              echo "Git status not clean. Did you forget to build the action before committing?"
+              exit 1
+            fi
 
 workflows:
   check:


### PR DESCRIPTION
This adds a check in the CI to ensure that after running `yarn build` there are no unstaged changes in the repo.

It acts as a proof that the code in dist/index.js has not been tampered with and is indeed the bundled code of the action with its dependencies.