### PR TITLE
Always use the PR's title as the squashed commit's title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosquash",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "files": [
     "action.yml",

--- a/src/autosquash.ts
+++ b/src/autosquash.ts
@@ -288,6 +288,7 @@ const merge = async ({
     body,
     head: { sha },
     number: pullRequestNumber,
+    title,
     user: { login: pullRequestCreator },
   },
   repo,
@@ -308,6 +309,7 @@ const merge = async ({
     info("Attempting merge");
     await github.pulls.merge({
       commit_message: getSquashedCommitMessage({ body, coAuthors }),
+      commit_title: title,
       merge_method: "squash",
       owner,
       pull_number: pullRequestNumber,

--- a/src/autosquash.ts
+++ b/src/autosquash.ts
@@ -309,7 +309,8 @@ const merge = async ({
     info("Attempting merge");
     await github.pulls.merge({
       commit_message: getSquashedCommitMessage({ body, coAuthors }),
-      commit_title: title,
+      // Same syntax GitHub uses by default.
+      commit_title: `${title} (#${pullRequestNumber})`,
       merge_method: "squash",
       owner,
       pull_number: pullRequestNumber,


### PR DESCRIPTION
Fix #34.